### PR TITLE
[JENKINS-60794] Add Configuration for DataTables Extensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,9 @@
     <revision>1.10.20-7-beta1</revision>
     <changelist>-SNAPSHOT</changelist>
     <datatables.version>1.10.20</datatables.version>
+    <datatables-responsive.version>2.2.3</datatables-responsive.version>
+    <datatables-colreorder.version>1.5.1</datatables-colreorder.version>
+    <datatables-buttons.version>1.6.1</datatables-buttons.version>
     <jquery3-api.version>3.4.1-3-beta1</jquery3-api.version>
     <font-awesome-api.version>5.12.0-1-beta1</font-awesome-api.version>
     <bootstrap4-api.version>4.4.1-4-beta1</bootstrap4-api.version>
@@ -102,6 +105,24 @@
       <groupId>org.webjars</groupId>
       <artifactId>datatables</artifactId>
       <version>${datatables.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>datatables-responsive</artifactId>
+      <version>${datatables-responsive.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>datatables-colreorder</artifactId>
+      <version>${datatables-colreorder.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>datatables-buttons</artifactId>
+      <version>${datatables-buttons.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -226,7 +247,7 @@
             </goals>
             <configuration>
               <outputDirectory>${project.build.directory}/webjars</outputDirectory>
-              <includeArtifactIds>datatables</includeArtifactIds>
+              <includeArtifactIds>datatables,datatables-responsive,datatables-colreorder,datatables-buttons</includeArtifactIds>
             </configuration>
           </execution>
         </executions>
@@ -247,6 +268,24 @@
                 <resource>
                   <directory>
                     ${project.build.directory}/webjars/META-INF/resources/webjars/datatables/${datatables.version}
+                  </directory>
+                  <filtering>false</filtering>
+                </resource>
+                <resource>
+                  <directory>
+                    ${project.build.directory}/webjars/META-INF/resources/webjars/datatables-responsive/${datatables-responsive.version}
+                  </directory>
+                  <filtering>false</filtering>
+                </resource>
+                <resource>
+                  <directory>
+                    ${project.build.directory}/webjars/META-INF/resources/webjars/datatables-colreorder/${datatables-colreorder.version}
+                  </directory>
+                  <filtering>false</filtering>
+                </resource>
+                <resource>
+                  <directory>
+                    ${project.build.directory}/webjars/META-INF/resources/webjars/datatables-buttons/${datatables-buttons.version}
                   </directory>
                   <filtering>false</filtering>
                 </resource>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>2.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <changelist>-SNAPSHOT</changelist>
     <datatables.version>1.10.20</datatables.version>
     <datatables-responsive.version>2.2.3</datatables-responsive.version>
-    <datatables-colreorder.version>1.5.1</datatables-colreorder.version>
+    <datatables-colreorder.version>1.5.1-1</datatables-colreorder.version>
     <datatables-buttons.version>1.6.1</datatables-buttons.version>
     <jquery3-api.version>3.4.1-3-beta1</jquery3-api.version>
     <font-awesome-api.version>5.12.0-1-beta1</font-awesome-api.version>

--- a/src/main/java/io/jenkins/plugins/datatables/TableColumn.java
+++ b/src/main/java/io/jenkins/plugins/datatables/TableColumn.java
@@ -56,7 +56,10 @@ public class TableColumn {
      */
     public TableColumn(final String headerLabel, final String dataPropertyName) {
         this.headerLabel = headerLabel;
-        definition = String.format("{\"data\": \"%s\"}", dataPropertyName);
+        definition = String.format("{"
+                + "  \"data\": \"%s\","
+                + "  \"defaultContent\": \"\""
+                + "}", dataPropertyName);
     }
 
     /**
@@ -75,6 +78,7 @@ public class TableColumn {
         definition = String.format("{"
                 + "  \"type\": \"%s\","
                 + "  \"data\": \"%s\","
+                + "  \"defaultContent\": \"\","
                 + "  \"render\": {"
                 + "     \"_\": \"display\","
                 + "     \"sort\": \"sort\""

--- a/src/main/java/io/jenkins/plugins/datatables/TableConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/datatables/TableConfiguration.java
@@ -1,0 +1,129 @@
+package io.jenkins.plugins.datatables;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Provides a configuration for the whole DataTable. This is merged with a default configuration in table.js.
+ *
+ * @author Andreas Pabst
+ */
+public class TableConfiguration {
+
+    private final Map<String, Object> configuration = new HashMap<>();
+
+    private boolean useResponsive = false;
+    private boolean useColReorder = false;
+    private boolean useButtons = false;
+
+    /**
+     * Make the table responsive, i.e. the columns wrap over to a child column.
+     *
+     * @return this {@link TableConfiguration} for chaining methods
+     */
+    public TableConfiguration responsive() {
+        this.configuration.put("responsive", true);
+        this.useResponsive = true;
+        return this;
+    }
+
+    /**
+     * Returns whether the responsive extension was configured to be used.
+     *
+     * @return true, if the responsive extension should be used, false otherwise
+     */
+    public boolean isUseResponsive() {
+        return useResponsive;
+    }
+
+    /**
+     * Enable reordering of table columns.
+     *
+     * @return this {@link TableConfiguration} for chaining methods
+     */
+    public TableConfiguration colReorder() {
+        this.configuration.put("colReorder", true);
+        this.useColReorder = true;
+        return this;
+    }
+
+    /**
+     * Returns whether column reordering was configured to be used.
+     *
+     * @return true, if column reordering should be used, false otherwise
+     */
+    public boolean isUseColReorder() {
+        return useColReorder;
+    }
+
+    /**
+     * Enable the default buttons.
+     *
+     * @return this {@link TableConfiguration} for chaining methods
+     */
+    public TableConfiguration buttons() {
+        this.configuration.put("buttons", true);
+        this.useButtons = true;
+        return this;
+    }
+
+    /**
+     * Enable specific buttons.
+     *
+     * @param types
+     *         List of buttons to use
+     *
+     * @return this {@link TableConfiguration} for chaining methods
+     */
+    public TableConfiguration buttons(final String... types) {
+        this.configuration.put("buttons", types);
+        this.useButtons = true;
+        return this;
+    }
+
+    /**
+     * Returns whether buttons were configured to be used.
+     *
+     * @return true, if buttons should be used, false otherwise
+     */
+    public boolean isUseButtons() {
+        return useButtons;
+    }
+
+    /**
+     * Enable saving of the table state.
+     *
+     * @return this {@link TableConfiguration} for chaining methods
+     */
+    public TableConfiguration stateSave() {
+        this.configuration.put("stateSave", true);
+        return this;
+    }
+
+    /**
+     * Get the configuration as JSON.
+     *
+     * @return a JSON Object with the configuration
+     */
+    public String getConfiguration() {
+        try {
+            return new ObjectMapper().writeValueAsString(configuration);
+        }
+        catch (JsonProcessingException exception) {
+            throw new IllegalArgumentException(
+                    String.format("Can't convert table configuration '%s' to JSON object", configuration), exception);
+        }
+    }
+
+    /**
+     * Empty Object to be used when creating the configuration. By default, Jackson refuses to create empty JSON
+     * objects, but this can be changed via the @{@link JsonSerialize} annotation.
+     */
+    @JsonSerialize
+    private static class EmptyConfigObject {
+    }
+}

--- a/src/main/java/io/jenkins/plugins/datatables/TableConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/datatables/TableConfiguration.java
@@ -24,6 +24,8 @@ public class TableConfiguration {
      * Make the table responsive, i.e. the columns wrap over to a child column.
      *
      * @return this {@link TableConfiguration} for chaining methods
+     *
+     * @see <a href="https://datatables.net/extensions/responsive/">https://datatables.net/extensions/responsive/</a>
      */
     public TableConfiguration responsive() {
         this.configuration.put("responsive", true);
@@ -44,6 +46,8 @@ public class TableConfiguration {
      * Enable reordering of table columns.
      *
      * @return this {@link TableConfiguration} for chaining methods
+     *
+     * @see <a href="https://datatables.net/extensions/colreorder/">https://datatables.net/extensions/colreorder/</a>
      */
     public TableConfiguration colReorder() {
         this.configuration.put("colReorder", true);
@@ -64,6 +68,8 @@ public class TableConfiguration {
      * Enable the default buttons.
      *
      * @return this {@link TableConfiguration} for chaining methods
+     *
+     * @see <a href="https://datatables.net/extensions/buttons/">https://datatables.net/extensions/buttons/</a>
      */
     public TableConfiguration buttons() {
         this.configuration.put("buttons", true);
@@ -78,6 +84,8 @@ public class TableConfiguration {
      *         List of buttons to use
      *
      * @return this {@link TableConfiguration} for chaining methods
+     *
+     * @see <a href="https://datatables.net/extensions/buttons/built-in">https://datatables.net/extensions/buttons/built-in</a> for more information on available buttons
      */
     public TableConfiguration buttons(final String... types) {
         this.configuration.put("buttons", types);
@@ -98,6 +106,8 @@ public class TableConfiguration {
      * Enable saving of the table state.
      *
      * @return this {@link TableConfiguration} for chaining methods
+     *
+     * @see <a href="https://datatables.net/reference/option/stateSave">https://datatables.net/reference/option/stateSave</a>
      */
     public TableConfiguration stateSave() {
         this.configuration.put("stateSave", true);

--- a/src/main/java/io/jenkins/plugins/datatables/TableModel.java
+++ b/src/main/java/io/jenkins/plugins/datatables/TableModel.java
@@ -49,6 +49,24 @@ public abstract class TableModel {
     public abstract List<Object> getRows();
 
     /**
+     * Returns the configuration of a table. This may be overridden to change the configuration of a table.
+     *
+     * @return the configuration
+     */
+    public TableConfiguration getTableConfiguration() {
+        return new TableConfiguration();
+    }
+
+    /**
+     * Returns the configuration of this table as JSON object.
+     *
+     * @return the table configuration JSON
+     */
+    public String getTableConfigurationDefinition() {
+        return getTableConfiguration().getConfiguration();
+    }
+
+    /**
      * A column value attribute that provides a {@code display} and {@code sort} property so that a JQuery DataTables
      * can use different properties to sort and display a column.
      */

--- a/src/main/resources/data-tables/table.jelly
+++ b/src/main/resources/data-tables/table.jelly
@@ -9,16 +9,33 @@
       The model of the table.
     </st:attribute>
 
+    <st:attribute name="class" use="optional" type="String">
+      Optional classes to be added to the table.
+    </st:attribute>
+
   </st:documentation>
 
   <st:adjunct includes="io.jenkins.plugins.jquery3"/>
   <st:adjunct includes="io.jenkins.plugins.bootstrap4"/>
   <st:adjunct includes="io.jenkins.plugins.data-tables"/>
+  <j:if test="${model.tableConfiguration.useResponsive}">
+    <st:adjunct includes="io.jenkins.plugins.data-tables-responsive"/>
+  </j:if>
+  <j:if test="${model.tableConfiguration.useColReorder}">
+    <st:adjunct includes="io.jenkins.plugins.data-tables-colreorder"/>
+  </j:if>
+  <j:if test="${model.tableConfiguration.useButtons}">
+    <st:adjunct includes="io.jenkins.plugins.data-tables-buttons"/>
+  </j:if>
   <st:adjunct includes="io.jenkins.plugins.bind-tables"/>
 
   <div class="table-responsive">
-    <table class="table table-hover table-striped data-table"
-           data-columns-definition="${model.columnsDefinition}" id="${model.id}">
+    <j:if test="${model.tableConfiguration.useButtons}">
+      <div class="table-buttons-container clearfix"/>
+    </j:if>
+    <table class="table table-hover table-striped data-table ${class}"
+           data-columns-definition="${model.columnsDefinition}" id="${model.id}"
+           data-table-configuration="${model.tableConfigurationDefinition}">
       <colgroup>
         <j:forEach var="c" items="${model.columns}">
           <col class="col-width-${c.width}"/>

--- a/src/main/resources/io/jenkins/plugins/data-tables-buttons.jelly
+++ b/src/main/resources/io/jenkins/plugins/data-tables-buttons.jelly
@@ -1,0 +1,21 @@
+<?jelly escape-by-default='true'?>
+<!--
+Use it like <st:adjunct includes="io.jenkins.plugins.data-tables-buttons"/>
+-->
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+
+  <j:new var="h" className="hudson.Functions"/>
+  ${h.initPageVariables(context)}
+
+  <st:adjunct includes="io.jenkins.plugins.jquery3"/>
+  <st:adjunct includes="io.jenkins.plugins.bootstrap4"/>
+  <st:adjunct includes="io.jenkins.plugins.data-tables"/>
+
+  <link type="text/css" rel="stylesheet"
+        href="${resURL}/plugin/data-tables-api/webjars/css/buttons.bootstrap4.min.css"/>
+
+  <script type="text/javascript" src="${resURL}/plugin/data-tables-api/webjars/js/dataTables.buttons.min.js"/>
+  <script type="text/javascript" src="${resURL}/plugin/data-tables-api/webjars/js/buttons.bootstrap4.min.js"/>
+
+  <script type="text/javascript" src="${resURL}/plugin/data-tables-api/webjars/js/buttons.colVis.min.js"/>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/data-tables-colreorder.jelly
+++ b/src/main/resources/io/jenkins/plugins/data-tables-colreorder.jelly
@@ -1,0 +1,19 @@
+<?jelly escape-by-default='true'?>
+<!--
+Use it like <st:adjunct includes="io.jenkins.plugins.data-tables-responsive"/>
+-->
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+
+  <j:new var="h" className="hudson.Functions"/>
+  ${h.initPageVariables(context)}
+
+  <st:adjunct includes="io.jenkins.plugins.jquery3"/>
+  <st:adjunct includes="io.jenkins.plugins.bootstrap4"/>
+  <st:adjunct includes="io.jenkins.plugins.data-tables"/>
+
+  <!--link type="text/css" rel="stylesheet" href="${resURL}/plugin/data-tables-api/webjars/css/colReorder.bootstrap4.scss"/-->
+
+  <script type="text/javascript" src="${resURL}/plugin/data-tables-api/webjars/js/dataTables.colReorder.js"/>
+  <script type="text/javascript" src="${resURL}/plugin/data-tables-api/webjars/js/colReorder.bootstrap4.js"/>
+
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/data-tables-colreorder.jelly
+++ b/src/main/resources/io/jenkins/plugins/data-tables-colreorder.jelly
@@ -11,9 +11,9 @@ Use it like <st:adjunct includes="io.jenkins.plugins.data-tables-colreorder"/>
   <st:adjunct includes="io.jenkins.plugins.bootstrap4"/>
   <st:adjunct includes="io.jenkins.plugins.data-tables"/>
 
-  <!--link type="text/css" rel="stylesheet" href="${resURL}/plugin/data-tables-api/webjars/css/colReorder.bootstrap4.scss"/-->
+  <link type="text/css" rel="stylesheet" href="${resURL}/plugin/data-tables-api/webjars/css/colReorder.bootstrap4.min.css"/>
 
-  <script type="text/javascript" src="${resURL}/plugin/data-tables-api/webjars/js/dataTables.colReorder.js"/>
-  <script type="text/javascript" src="${resURL}/plugin/data-tables-api/webjars/js/colReorder.bootstrap4.js"/>
+  <script type="text/javascript" src="${resURL}/plugin/data-tables-api/webjars/js/dataTables.colReorder.min.js"/>
+  <script type="text/javascript" src="${resURL}/plugin/data-tables-api/webjars/js/colReorder.bootstrap4.min.js"/>
 
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/data-tables-colreorder.jelly
+++ b/src/main/resources/io/jenkins/plugins/data-tables-colreorder.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <!--
-Use it like <st:adjunct includes="io.jenkins.plugins.data-tables-responsive"/>
+Use it like <st:adjunct includes="io.jenkins.plugins.data-tables-colreorder"/>
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
 

--- a/src/main/resources/io/jenkins/plugins/data-tables-responsive.jelly
+++ b/src/main/resources/io/jenkins/plugins/data-tables-responsive.jelly
@@ -1,0 +1,19 @@
+<?jelly escape-by-default='true'?>
+<!--
+Use it like <st:adjunct includes="io.jenkins.plugins.data-tables-responsive"/>
+-->
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+
+  <j:new var="h" className="hudson.Functions"/>
+  ${h.initPageVariables(context)}
+
+  <st:adjunct includes="io.jenkins.plugins.jquery3"/>
+  <st:adjunct includes="io.jenkins.plugins.bootstrap4"/>
+  <st:adjunct includes="io.jenkins.plugins.data-tables"/>
+
+  <link type="text/css" rel="stylesheet" href="${resURL}/plugin/data-tables-api/webjars/css/responsive.bootstrap4.min.css"/>
+
+  <script type="text/javascript" src="${resURL}/plugin/data-tables-api/webjars/js/dataTables.responsive.min.js"/>
+  <script type="text/javascript" src="${resURL}/plugin/data-tables-api/webjars/js/responsive.bootstrap4.min.js"/>
+
+</j:jelly>

--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -11,7 +11,7 @@ function bindTables() {
      * Creates the data table instance for the specified table element.
      */
     function createDataTable(table) {
-        return table.DataTable({
+        const defaultConfiguration = {
             language: {
                 emptyTable: 'Loading - please wait ...'
             },
@@ -41,7 +41,21 @@ function bindTables() {
                 }
             ],
             columns: JSON.parse(table.attr('data-columns-definition'))
-        });
+        };
+        const tableConfiguration = JSON.parse(table.attr('data-table-configuration'));
+        // overwrite/merge the default configuration with values from the provided table configuration
+        const dataTable = table.DataTable(Object.assign(defaultConfiguration, tableConfiguration));
+
+        // add the buttons to the top of the table
+        if (tableConfiguration.buttons) {
+            dataTable
+                .buttons()
+                .container()
+                .addClass('float-none mb-3')
+                .prependTo(jQuery3(dataTable.table().container()).closest('.table-responsive'));
+        }
+
+        return dataTable;
     }
 
     /**

--- a/src/test/java/io/jenkins/plugins/datatables/TableColumnTest.java
+++ b/src/test/java/io/jenkins/plugins/datatables/TableColumnTest.java
@@ -24,7 +24,7 @@ class TableColumnTest {
         TableColumn column = new TableColumn(LABEL, "one");
 
         assertThat(column).hasHeaderLabel(LABEL);
-        assertThat(column).hasDefinition("{\"data\": \"one\"}");
+        assertThat(column).hasDefinition("{  \"data\": \"one\",  \"defaultContent\": \"\"}");
         assertThat(column).hasHeaderClass(StringUtils.EMPTY);
         assertThat(column).hasWidth(1);
     }
@@ -35,7 +35,8 @@ class TableColumnTest {
 
         assertThat(column).hasHeaderLabel(LABEL);
         assertThat(column).hasDefinition("{  \"type\": \"integer\",  "
-                + "\"data\": \"one\",  "
+                + "\"data\": \"one\",  " 
+                + "\"defaultContent\": \"\",  "
                 + "\"render\": {     \"_\": \"display\",     \"sort\": \"sort\"  }}");
         assertThat(column).hasHeaderClass(StringUtils.EMPTY);
         assertThat(column).hasWidth(1);
@@ -48,7 +49,7 @@ class TableColumnTest {
                 .setWidth(WIDTH);
 
         assertThat(column).hasHeaderLabel(LABEL);
-        assertThat(column).hasDefinition("{\"data\": \"simple\"}");
+        assertThat(column).hasDefinition("{  \"data\": \"simple\",  \"defaultContent\": \"\"}");
         assertThat(column).hasHeaderClass("date");
         assertThat(column).hasWidth(WIDTH);
     }

--- a/src/test/java/io/jenkins/plugins/datatables/TableConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/datatables/TableConfigurationTest.java
@@ -1,0 +1,79 @@
+package io.jenkins.plugins.datatables;
+
+import org.junit.jupiter.api.Test;
+
+import static io.jenkins.plugins.datatables.TableConfigurationAssert.*;
+
+/**
+ * Tests for the class {@link TableConfiguration}.
+ *
+ * @author Andreas Pabst
+ */
+public class TableConfigurationTest {
+
+    @Test
+    void shouldCreateEmptyConfiguration() {
+        TableConfiguration configuration = new TableConfiguration();
+
+        assertThat(configuration).hasConfiguration("{}");
+        assertThat(configuration).isNotUseButtons();
+        assertThat(configuration).isNotUseColReorder();
+        assertThat(configuration).isNotUseResponsive();
+    }
+
+    @Test
+    void shouldCreateResponsiveConfiguration() {
+        TableConfiguration configuration = new TableConfiguration()
+                .responsive();
+
+        assertThat(configuration).hasConfiguration("{\"responsive\":true}");
+        assertThat(configuration).isNotUseButtons();
+        assertThat(configuration).isNotUseColReorder();
+        assertThat(configuration).isUseResponsive();
+    }
+
+    @Test
+    void shouldCreateColReorderConfiguration() {
+        TableConfiguration configuration = new TableConfiguration()
+                .colReorder();
+
+        assertThat(configuration).hasConfiguration("{\"colReorder\":true}");
+        assertThat(configuration).isNotUseButtons();
+        assertThat(configuration).isUseColReorder();
+        assertThat(configuration).isNotUseResponsive();
+    }
+
+    @Test
+    void shouldCreateButtonsDefaultConfiguration() {
+        TableConfiguration configuration = new TableConfiguration()
+                .buttons();
+
+        assertThat(configuration).hasConfiguration("{\"buttons\":true}");
+        assertThat(configuration).isUseButtons();
+        assertThat(configuration).isNotUseColReorder();
+        assertThat(configuration).isNotUseResponsive();
+    }
+
+    @Test
+    void shouldCreateSpecificButtonsConfiguration() {
+        TableConfiguration configuration = new TableConfiguration()
+                .buttons("colvis", "print");
+
+        assertThat(configuration).hasConfiguration("{\"buttons\":[\"colvis\",\"print\"]}");
+        assertThat(configuration).isUseButtons();
+        assertThat(configuration).isNotUseColReorder();
+        assertThat(configuration).isNotUseResponsive();
+    }
+
+    @Test
+    void shouldCreateSaveStateConfiguration() {
+        TableConfiguration configuration = new TableConfiguration()
+                .stateSave();
+
+        assertThat(configuration).hasConfiguration("{\"stateSave\":true}");
+        assertThat(configuration).isNotUseButtons();
+        assertThat(configuration).isNotUseColReorder();
+        assertThat(configuration).isNotUseResponsive();
+    }
+
+}


### PR DESCRIPTION
This PR adds three DataTables Extensions (Responsive, ColReorder and Buttons) and a basic configuration option for all of them. This may have to be extended in the future to allow for better configuration.

See also [JENKINS-60794](https://issues.jenkins-ci.org/browse/JENKINS-60794)