### PR TITLE
Update to remove old forceAci parameter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@
         String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
         boolean first = tasks.size() == 1
         boolean skipTests = params?.tests?.skip
-        boolean addToolEnv = !reallyUseAci
+        boolean addToolEnv = !useAci
 
         if(useAci && (label == 'linux' || label == 'windows')) {
             String aciLabel = jdk == '8' ? 'maven' : 'maven-11'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,10 +29,9 @@
         String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
         boolean first = tasks.size() == 1
         boolean skipTests = params?.tests?.skip
-        boolean reallyUseAci = (useAci && label == 'linux') || forceAci
         boolean addToolEnv = !reallyUseAci
 
-        if(reallyUseAci) {
+        if(useAci && (label == 'linux' || label == 'windows')) {
             String aciLabel = jdk == '8' ? 'maven' : 'maven-11'
             if(label == 'windows') {
                 aciLabel += "-windows"


### PR DESCRIPTION
Updated to follow what is in the buildPlugin.groovy from the global pipeline library.

Is there a reason that you aren't using buildPlugin() directly? Maybe something we could implement in the global library so we can keep a single source of buildPlugin?