### PR TITLE
Fix right alignment for Bootstrap 5

### DIFF
--- a/src/main/java/io/jenkins/plugins/datatables/TableColumn.java
+++ b/src/main/java/io/jenkins/plugins/datatables/TableColumn.java
@@ -162,9 +162,9 @@ public class TableColumn {
          */
         DATE("date"),
         /**
-         * Numbers will be shown right aligned so they can be compared more easily..
+         * Numbers will be shown right aligned, so they can be compared more easily.
          */
-        NUMBER("text-right"),
+        NUMBER("text-end"),
         /** Disables sorting of the column. Rendering is the same as with {@code NONE}. */
         NO_SORT("nosort"),
         /** Hides the column for view. It still exists and responds to searching */

--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -21,8 +21,8 @@ jQuery3(document).ready(function () {
                         orderable: false
                     },
                     {
-                        targets: 'text-right', // All columns with the '.text-right' class in the <th>
-                        className: 'text-right'
+                        targets: 'text-end', // All columns with the '.text-right' class in the <th>
+                        className: 'text-end'
                     },
                     {
                         targets: 'date', // All columns with the '.date' class in the <th>


### PR DESCRIPTION
In BS5 the class 'text-end' is used rather than 'text-right'.

See https://getbootstrap.com/docs/5.0/utilities/text/#text-alignment.
