### PR TITLE
Fix `isLoaded` attribute of tables

### DIFF
--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -81,11 +81,12 @@ jQuery3(document).ready(function () {
          */
         function loadTableData(table, dataTable) {
             if (!table[0].hasAttribute('isLoaded')) {
-                table.attr('isLoaded', 'true');
+                table.attr('isLoaded', 'false');
                 tableDataProxy.getTableRows(table.attr('id'), function (t) {
                     (function () {
                         const model = JSON.parse(t.responseObject());
                         dataTable.rows.add(model).draw();
+                        table.attr('isLoaded', 'true');
                     })();
                 });
             }


### PR DESCRIPTION
Tables will get an additional attribute `isLoaded` that is filled with `false` before the AJAX call has been started and with `true` after all elements have been filled with the results of the AJAX call into the table. This simplifies initialization of page objects for UI tests.