### PR TITLE
Added select include to table.jelly

### DIFF
--- a/src/main/resources/data-tables/table.jelly
+++ b/src/main/resources/data-tables/table.jelly
@@ -27,6 +27,9 @@
   <j:if test="${model.tableConfiguration.useButtons}">
     <st:adjunct includes="io.jenkins.plugins.data-tables-buttons"/>
   </j:if>
+  <j:if test="${model.tableConfiguration.useSelect}">
+    <st:adjunct includes="io.jenkins.plugins.data-tables-select"/>
+  </j:if>
   <st:adjunct includes="io.jenkins.plugins.bind-tables"/>
 
   <div class="table-responsive">


### PR DESCRIPTION
I added the include of the select option to the `table.jelly`. Otherwise, the import is missing.
