### PR TITLE
Expose RevApi infinite loop in `differences`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,93 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <version>${revapi-maven-plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.revapi</groupId>
+            <artifactId>revapi-java</artifactId>
+            <version>${revapi-java.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.revapi</groupId>
+            <artifactId>revapi-reporter-json</artifactId>
+            <version>${revapi-reporter-json-version}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.jenkins.tools</groupId>
+            <artifactId>revapi-hpi-extractor</artifactId>
+            <version>1.0.1</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <versionFormat>[-0-9.]*</versionFormat>
+          <failBuildOnProblemsFound>true</failBuildOnProblemsFound>
+          <analysisConfiguration>
+            <revapi.versions>
+              <enabled>true</enabled>
+            </revapi.versions>
+            <!-- Exclude of the hudson package not working-->
+            <revapi.filter>
+              <elements>
+                <exclude>
+                  <item>
+                    <matcher>java-package</matcher>
+                    <match>/org\.jvnet\.hudson(\..*)?/</match>
+                  </item>
+                  <item>
+                    <matcher>java-package</matcher>
+                    <match>/net\.sf\.json(\..*)?/</match>
+                  </item>
+                  <item>
+                    <matcher>java-package</matcher>
+                    <match>/hudson(\..*)?/</match>
+                  </item>
+                  <item>
+                    <matcher>java-package</matcher>
+                    <match>/org.kohsuke(\..*)?/</match>
+                  </item>
+                </exclude>
+              </elements>
+            </revapi.filter>
+            <revapi.reporter.json>
+              <minSeverity>NON_BREAKING</minSeverity>
+              <minCriticality>documented</minCriticality>
+              <output>${project.build.outputDirectory}/revapi-result.json</output>
+              <indent>false</indent>
+              <append>false</append>
+              <keepEmptyFile>true</keepEmptyFile>
+            </revapi.reporter.json>
+            <revapi.differences>
+              <justification>Not relevant changes that are safe to ignore</justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <regex>true</regex>
+                  <code>java.annotation.*</code>
+                  <annotationType>edu.umd.cs.findbugs.annotations.*</annotationType>
+                  <justification>Annotation should be safe to change</justification>
+                </item>
+                <item>
+                  <regex>true</regex>
+                  <code>java.method.parameterTypeChanged</code>
+                </item>
+              </differences>
+            </revapi.differences>
+          </analysisConfiguration>
+        </configuration>
+        <executions>
+          <execution>
+            <id>run-revapi</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Exposes a RevApi infinite loop:
 
```
[WARNING] Transformation of differences in match report Report[oldElement=parameter io.jenkins.plugins.datatables.TableConfiguration io.jenkins.plugins.datatables.TableConfiguration::select(===io.jenkins.plugins.datatables.options.SelectStyle===), newElement=parameter io.jenkins.plugins.datatables.TableConfiguration io.jenkins.plugins.datatables.TableConfiguration::select(===io.jenkins.plugins.datatables.TableConfiguration.SelectStyle===), problems=[Difference[code='java.method.parameterTypeChanged', name='parameter type changed', classification={SOURCE=POTENTIALLY_BREAKING, BINARY=BREAKING}, description='The type of the parameter changed from 'io.jenkins.plugins.datatables.options.SelectStyle' to 'io.jenkins.plugins.datatables.TableConfiguration.SelectStyle'.', justification='Not relevant changes that are safe to ignore', criticality='Criticality[name='error', level=2147483647]'], Difference[code='java.method.parameterTypeChanged', name='parameter type changed', classification={SOURCE=POTENTIALLY_BREAKING, BINARY=BREAKING}, description='The type of the parameter changed from 'io.jenkins.plugins.datatables.options.SelectStyle' to 'io.jenkins.plugins.datatables.TableConfiguration.SelectStyle'.', justification='null', criticality='Criticality[name='error', level=2147483647]']]] has cycled 381000 times. Maybe we're in an infinite loop with differences transforming back and forth?
```

When I remove the offending difference:
```
<item>
  <regex>true</regex>
  <code>java.method.parameterTypeChanged</code>
</item>
```

then RevApi correctly complains about an API problem.
