### PR TITLE
Expose RevApi infinite loop while scanning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>5.28.0</version>
+    <version>5.30.0</version>
     <relativePath />
   </parent>
 
@@ -242,77 +242,6 @@
                 <include>**/*PageObject*</include>
               </includes>
             </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.revapi</groupId>
-        <artifactId>revapi-maven-plugin</artifactId>
-        <version>${revapi-maven-plugin.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.revapi</groupId>
-            <artifactId>revapi-java</artifactId>
-            <version>${revapi-java.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.revapi</groupId>
-            <artifactId>revapi-reporter-json</artifactId>
-            <version>${revapi-reporter-json-version}</version>
-          </dependency>
-          <dependency>
-            <groupId>io.jenkins.tools</groupId>
-            <artifactId>revapi-hpi-extractor</artifactId>
-            <version>1.0.1</version>
-          </dependency>
-        </dependencies>
-        <configuration>
-          <versionFormat>[-0-9.]*</versionFormat>
-          <failBuildOnProblemsFound>true</failBuildOnProblemsFound>
-          <analysisConfiguration>
-            <revapi.versions>
-              <enabled>true</enabled>
-            </revapi.versions>
-            <!-- Exclude of the hudson package not working-->
-            <revapi.filter>
-              <elements>
-                <exclude>
-                  <item>
-                    <matcher>java-package</matcher>
-                    <match>/nothing(\..*)?/</match>
-                  </item>
-                </exclude>
-              </elements>
-            </revapi.filter>
-            <revapi.reporter.json>
-              <minSeverity>NON_BREAKING</minSeverity>
-              <minCriticality>documented</minCriticality>
-              <output>${project.build.outputDirectory}/revapi-result.json</output>
-              <indent>false</indent>
-              <append>false</append>
-              <keepEmptyFile>true</keepEmptyFile>
-            </revapi.reporter.json>
-            <revapi.differences>
-              <justification>Not relevant changes that are safe to ignore</justification>
-              <criticality>allowed</criticality>
-              <differences>
-                <item>
-                  <regex>true</regex>
-                  <code>java.annotation.*</code>
-                  <annotationType>edu.umd.cs.findbugs.annotations.*</annotationType>
-                  <justification>Annotation should be safe to change</justification>
-                </item>
-              </differences>
-            </revapi.differences>
-          </analysisConfiguration>
-        </configuration>
-        <executions>
-          <execution>
-            <id>run-revapi</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <phase>verify</phase>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -279,19 +279,7 @@
                 <exclude>
                   <item>
                     <matcher>java-package</matcher>
-                    <match>/org\.jvnet\.hudson(\..*)?/</match>
-                  </item>
-                  <item>
-                    <matcher>java-package</matcher>
-                    <match>/net\.sf\.json(\..*)?/</match>
-                  </item>
-                  <item>
-                    <matcher>java-package</matcher>
-                    <match>/hudson(\..*)?/</match>
-                  </item>
-                  <item>
-                    <matcher>java-package</matcher>
-                    <match>/org.kohsuke(\..*)?/</match>
+                    <match>/nothing(\..*)?/</match>
                   </item>
                 </exclude>
               </elements>
@@ -313,10 +301,6 @@
                   <code>java.annotation.*</code>
                   <annotationType>edu.umd.cs.findbugs.annotations.*</annotationType>
                   <justification>Annotation should be safe to change</justification>
-                </item>
-                <item>
-                  <regex>true</regex>
-                  <code>java.method.parameterTypeChanged</code>
                 </item>
               </differences>
             </revapi.differences>

--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,93 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <version>${revapi-maven-plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.revapi</groupId>
+            <artifactId>revapi-java</artifactId>
+            <version>${revapi-java.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.revapi</groupId>
+            <artifactId>revapi-reporter-json</artifactId>
+            <version>${revapi-reporter-json-version}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.jenkins.tools</groupId>
+            <artifactId>revapi-hpi-extractor</artifactId>
+            <version>1.0.1</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <versionFormat>[-0-9.]*</versionFormat>
+          <failBuildOnProblemsFound>true</failBuildOnProblemsFound>
+          <analysisConfiguration>
+            <revapi.versions>
+              <enabled>true</enabled>
+            </revapi.versions>
+            <!-- Exclude of the hudson package not working-->
+            <revapi.filter>
+              <elements>
+                <exclude>
+                  <item>
+                    <matcher>java-package</matcher>
+                    <match>/org\.jvnet\.hudson(\..*)?/</match>
+                  </item>
+                  <item>
+                    <matcher>java-package</matcher>
+                    <match>/net\.sf\.json(\..*)?/</match>
+                  </item>
+                  <item>
+                    <matcher>java-package</matcher>
+                    <match>/hudson(\..*)?/</match>
+                  </item>
+                  <item>
+                    <matcher>java-package</matcher>
+                    <match>/org.kohsuke(\..*)?/</match>
+                  </item>
+                </exclude>
+              </elements>
+            </revapi.filter>
+            <revapi.reporter.json>
+              <minSeverity>NON_BREAKING</minSeverity>
+              <minCriticality>documented</minCriticality>
+              <output>${project.build.outputDirectory}/revapi-result.json</output>
+              <indent>false</indent>
+              <append>false</append>
+              <keepEmptyFile>true</keepEmptyFile>
+            </revapi.reporter.json>
+            <revapi.differences>
+              <justification>Not relevant changes that are safe to ignore</justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <regex>true</regex>
+                  <code>java.annotation.*</code>
+                  <annotationType>edu.umd.cs.findbugs.annotations.*</annotationType>
+                  <justification>Annotation should be safe to change</justification>
+                </item>
+                <item>
+                  <regex>true</regex>
+                  <code>java.method.parameterTypeChanged</code>
+                </item>
+              </differences>
+            </revapi.differences>
+          </analysisConfiguration>
+        </configuration>
+        <executions>
+          <execution>
+            <id>run-revapi</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Exposes https://github.com/revapi/revapi/issues/271.

Note that the parent pom also includes a revapi configuration so make sure to look at the effective pom.

When I exclude some packages (see https://github.com/jenkinsci/analysis-pom-plugin/blob/master/pom.xml#L511-L530) then everything works fine. 