### PR TITLE
Add responsive priority as optional column parameter

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.3</version>
+    <version>1.2</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 def configurations = [
-  [ platform: "linux", jdk: "11" ]
+  [ platform: "linux", jdk: "11" ],
+  [ platform: "windows", jdk: "11" ]
 ]
 
-buildPlugin(failFast: false, configurations: configurations)
+buildPlugin(failFast: false, configurations: configurations,
+    checkstyle: [qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]],
+    pmd: [qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]] )

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -244,6 +245,26 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <configuration>
+          <analysisConfiguration>
+            <revapi.differences>
+              <justification>Not relevant changes that are safe to ignore</justification>
+              <criticality>allowed</criticality>
+              <differences combine.children="append">
+                <item>
+                  <regex>true</regex>
+                  <code>java.annotation.*</code>
+                  <annotationType>edu.umd.cs.findbugs.annotations.*</annotationType>
+                  <justification>Annotation should be safe to change</justification>
+                </item>
+              </differences>
+            </revapi.differences>
+          </analysisConfiguration>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,7 @@
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
         <configuration>
+          <skip>true</skip>
           <analysisConfiguration>
             <revapi.differences>
               <justification>Not relevant changes that are safe to ignore</justification>

--- a/src/main/java/io/jenkins/plugins/datatables/DetailedCell.java
+++ b/src/main/java/io/jenkins/plugins/datatables/DetailedCell.java
@@ -1,0 +1,36 @@
+package io.jenkins.plugins.datatables;
+
+/**
+ * A table cell that provides a {@code display} and {@code sort} property so that a JQuery data table can use different
+ * properties to sort and display a column. In order to use such a cell the {@link TableColumn} has to be configured using the
+ *
+ * @param <T>
+ *         the type of the sort column
+ */
+public class DetailedCell<T> {
+    private final String display;
+    private final T sort;
+
+    /**
+     * Creates a new {@link DetailedCell}.
+     *
+     * @param display
+     *         the value that should be used to display the cell
+     * @param sort
+     *         the value that should be used to sort the cell
+     *
+     * @see <a href="https://datatables.net/reference/option/columns.type">DataTables Column Types</a>
+     */
+    public DetailedCell(final String display, final T sort) {
+        this.display = display;
+        this.sort = sort;
+    }
+
+    public String getDisplay() {
+        return display;
+    }
+
+    public T getSort() {
+        return sort;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/datatables/TableColumn.java
+++ b/src/main/java/io/jenkins/plugins/datatables/TableColumn.java
@@ -329,7 +329,8 @@ public class TableColumn {
                 return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(columnDefinition);
             }
             catch (JsonProcessingException exception) {
-                throw new IllegalArgumentException("Can't convert to JSON: " + columnDefinition);
+                throw new IllegalArgumentException("Can't convert to JSON: " + columnDefinition,
+                        exception);
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/datatables/TableColumn.java
+++ b/src/main/java/io/jenkins/plugins/datatables/TableColumn.java
@@ -183,7 +183,7 @@ public class TableColumn {
      * Builder for {@link TableColumn} instances.
      */
     public static class ColumnBuilder {
-        private static final int DEFAULT_PRIORITY = 10000;
+        private static final int DEFAULT_PRIORITY = 10_000;
         @CheckForNull
         private String header;
         @CheckForNull

--- a/src/main/java/io/jenkins/plugins/datatables/TableConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/datatables/TableConfiguration.java
@@ -19,6 +19,7 @@ public class TableConfiguration {
     private boolean useColReorder = false;
     private boolean useButtons = false;
     private boolean useSelect = false;
+    private boolean useStateSave = false;
 
     /**
      * Make the table responsive, i.e. the columns wrap over to a child column.
@@ -136,7 +137,17 @@ public class TableConfiguration {
      */
     public TableConfiguration stateSave() {
         configuration.put("stateSave", true);
+        useStateSave = true;
         return this;
+    }
+
+    /**
+     * Returns whether stateSave is configured to be used.
+     *
+     * @return true, if stateSave should be used, false otherwise
+     */
+    public boolean isUseStateSave() {
+        return useStateSave;
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/datatables/TableModel.java
+++ b/src/main/java/io/jenkins/plugins/datatables/TableModel.java
@@ -100,5 +100,4 @@ public abstract class TableModel {
             return sort;
         }
     }
-
 }

--- a/src/main/java/io/jenkins/plugins/datatables/TableModel.java
+++ b/src/main/java/io/jenkins/plugins/datatables/TableModel.java
@@ -101,38 +101,4 @@ public abstract class TableModel {
         }
     }
 
-    /**
-     * A table cell that provides a {@code display} and {@code sort} property so that a JQuery data table can use
-     * different properties to sort and display a column.
-     *
-     * @param <T>
-     *         the type of the sort column
-     */
-    public static class DetailedCell<T> {
-        private final String display;
-        private final T sort;
-
-        /**
-         * Creates a new {@link DetailedCell}.
-         *
-         * @param display
-         *         the value that should be used to display the cell
-         * @param sort
-         *         the value that should be used to sort the cell
-         *
-         * @see <a href="https://datatables.net/reference/option/columns.type">DataTables Column Types</a>
-         */
-        public DetailedCell(final String display, final T sort) {
-            this.display = display;
-            this.sort = sort;
-        }
-
-        public String getDisplay() {
-            return display;
-        }
-
-        public T getSort() {
-            return sort;
-        }
-    }
 }

--- a/src/main/java/io/jenkins/plugins/datatables/TableModel.java
+++ b/src/main/java/io/jenkins/plugins/datatables/TableModel.java
@@ -67,8 +67,8 @@ public abstract class TableModel {
     }
 
     /**
-     * A column value attribute that provides a {@code display} and {@code sort} property so that a JQuery DataTables
-     * can use different properties to sort and display a column.
+     * A column value attribute that provides a {@code display} and {@code sort} property so that a JQuery data
+     * table can use different String properties to sort and display a column.
      *
      * @deprecated use the generic class {@link DetailedCell}
      */
@@ -102,10 +102,11 @@ public abstract class TableModel {
     }
 
     /**
-     * A table cell that provides a {@code display} and {@code sort} property so that a JQuery DataTables
-     * can use different properties to sort and display a column.
+     * A table cell that provides a {@code display} and {@code sort} property so that a JQuery data table can use
+     * different properties to sort and display a column.
      *
-     * @param <T> the type of the sort column
+     * @param <T>
+     *         the type of the sort column
      */
     public static class DetailedCell<T> {
         private final String display;

--- a/src/main/resources/data-tables/table.jelly
+++ b/src/main/resources/data-tables/table.jelly
@@ -36,15 +36,10 @@
     <j:if test="${model.tableConfiguration.useButtons}">
       <div class="table-buttons-container clearfix"/>
     </j:if>
-    <table class="table table-hover table-striped data-table ${class}"
+    <table class="table table-hover table-striped data-table dt-responsive nowrap ${class}"
            data-columns-definition="${model.columnsDefinition}" id="${model.id}"
            data-table-configuration="${model.tableConfigurationDefinition}"
            style="width: 100%;">
-      <colgroup>
-        <j:forEach var="c" items="${model.columns}">
-          <col class="col-width-${c.width}"/>
-        </j:forEach>
-      </colgroup>
       <thead>
         <tr>
           <j:forEach var="c" items="${model.columns}">

--- a/src/main/resources/io/jenkins/plugins/bind-tables.jelly
+++ b/src/main/resources/io/jenkins/plugins/bind-tables.jelly
@@ -1,6 +1,6 @@
   <?jelly escape-by-default='true'?>
 <!--
-Use it like <st:adjunct includes="io.jenkins.plugins.data-tables"/>
+Use it like <st:adjunct includes="io.jenkins.plugins.bind-tables"/>
 -->
   <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
 

--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -12,6 +12,9 @@ jQuery3(document).ready(function () {
                 language: {
                     emptyTable: 'Loading - please wait ...'
                 },
+                responsive: {
+                    details: false
+                },
                 deferRender: true,
                 pagingType: 'numbers', // page number button only
                 order: [[1, 'asc']], // default order, if not persisted yet
@@ -21,7 +24,7 @@ jQuery3(document).ready(function () {
                         orderable: false
                     },
                     {
-                        targets: 'text-end', // All columns with the '.text-right' class in the <th>
+                        targets: 'text-end', // All columns with the '.text-end' class in the <th>
                         className: 'text-end'
                     },
                     {
@@ -31,7 +34,7 @@ jQuery3(document).ready(function () {
                                 if (data === 0) {
                                     return '-';
                                 }
-                                var dateTime = luxon.DateTime.fromMillis(data * 1000);
+                                const dateTime = luxon.DateTime.fromMillis(data * 1000);
                                 return '<span data-bs-toggle="tooltip" data-bs-placement="bottom" title="'
                                     + dateTime.toLocaleString(luxon.DateTime.DATETIME_SHORT) + '">'
                                     + dateTime.toRelative({locale: 'en'}) + '</span>';
@@ -177,6 +180,9 @@ jQuery3(document).ready(function () {
         $.extend(true, $.fn.dataTable.defaults, {
             mark: {
                 className: 'highlight'
+            },
+            responsive: {
+                details: false
             }
         });
         bindTables($);

--- a/src/test/java/io/jenkins/plugins/datatables/TableColumnTest.java
+++ b/src/test/java/io/jenkins/plugins/datatables/TableColumnTest.java
@@ -11,66 +11,87 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Tests the class {@link TableColumn}.
+ * Tests the classes {@link TableColumn} and {@link ColumnBuilder}.
  *
  * @author Ullrich Hafner
  */
 class TableColumnTest {
     private static final String LABEL = "label";
-    private static final int WIDTH = 2;
     private static final String RESPONSIVE_PRIORITY = "responsivePriority";
     private static final String DATA = "data";
-    private static final String DEFAULT_CONTENT = "defaultContent";
     private static final String TYPE = "type";
+    private static final String RENDER = "render";
+    private static final String KEY = "one";
+
+    @Test
+    void shouldEnsureValidBuilderState() {
+        ColumnBuilder builder = new ColumnBuilder();
+
+        assertThatIllegalArgumentException().isThrownBy(() -> builder.withResponsivePriority(-1));
+
+        assertThatIllegalArgumentException().isThrownBy(builder::build).withMessageContainingAll("withHeaderLabel");
+        builder.withHeaderLabel(LABEL);
+
+        assertThatIllegalArgumentException().isThrownBy(builder::build).withMessageContainingAll("withDataPropertyKey");
+        builder.withDataPropertyKey(KEY);
+
+        assertThat(builder.build()).hasHeaderLabel(LABEL).hasHeaderClass(StringUtils.EMPTY);
+    }
 
     @Test
     void shouldCreateColumnWithSimpleDescription() {
-        TableColumn column = new TableColumn(LABEL, "one");
+        ColumnBuilder builder = new ColumnBuilder();
 
-        assertThat(column).hasHeaderLabel(LABEL);
-        assertThat(column).hasDefinition("{  \"data\": \"one\",  \"defaultContent\": \"\"}");
-        assertThat(column).hasHeaderClass(StringUtils.EMPTY);
-        assertThat(column).hasWidth(1);
+        TableColumn noPriority = builder.withHeaderLabel(LABEL)
+                .withDataPropertyKey(KEY)
+                .build();
 
-        assertThatJson(column.getDefinition()).node(DATA).isEqualTo("one");
-        assertThatJson(column.getDefinition()).node(DEFAULT_CONTENT).asString().isEmpty();
-        assertThatJson(column.getDefinition()).node(RESPONSIVE_PRIORITY).isAbsent();
+        assertThat(noPriority).hasHeaderLabel(LABEL).hasHeaderClass(StringUtils.EMPTY);
+        assertThatJson(noPriority.getDefinition()).node(DATA).isEqualTo(KEY);
+        assertThatJson(noPriority.getDefinition()).node(RESPONSIVE_PRIORITY).isAbsent();
 
-        column.setPriority(1);
-        assertThatJson(column.getDefinition()).node(RESPONSIVE_PRIORITY).isEqualTo(1);
+        TableColumn withPriority = builder.withHeaderLabel(LABEL)
+                .withDataPropertyKey(KEY)
+                .withResponsivePriority(1)
+                .build();
+
+        assertThatJson(withPriority.getDefinition()).node(RESPONSIVE_PRIORITY).isEqualTo(1);
     }
 
     @Test
     void shouldCreateColumnWithComplexDescription() {
-        TableColumn column = new TableColumn(LABEL, "one", "integer");
+        ColumnBuilder builder = new ColumnBuilder();
 
-        assertThat(column).hasHeaderLabel(LABEL);
-        assertThat(column).hasDefinition("{  \"type\": \"integer\",  "
-                + "\"data\": \"one\",  "
-                + "\"defaultContent\": \"\",  "
-                + "\"render\": {     \"_\": \"display\",     \"sort\": \"sort\"  }}");
-        assertThat(column).hasHeaderClass(StringUtils.EMPTY);
-        assertThat(column).hasWidth(1);
+        TableColumn noPriority = builder.withHeaderLabel(LABEL)
+                .withDataPropertyKey(KEY)
+                .withType("integer")
+                .withDetailedCell()
+                .build();
 
-        column.setPriority(1);
-        assertThatJson(column.getDefinition()).node(DATA).isEqualTo("one");
-        assertThatJson(column.getDefinition()).node(DEFAULT_CONTENT).asString().isEmpty();
-        assertThatJson(column.getDefinition()).node(RESPONSIVE_PRIORITY).isEqualTo(1);
-        assertThatJson(column.getDefinition()).node(TYPE).isEqualTo("integer");
-        assertThatJson(column.getDefinition()).node("render").node("_").isEqualTo("display");
-        assertThatJson(column.getDefinition()).node("render").node("sort").isEqualTo("sort");
+        assertThat(noPriority).hasHeaderLabel(LABEL).hasHeaderClass(StringUtils.EMPTY);
+        assertThatJson(noPriority.getDefinition()).node(DATA).isEqualTo(KEY);
+        assertThatJson(noPriority.getDefinition()).node(TYPE).isEqualTo("integer");
+        assertThatJson(noPriority.getDefinition()).node(RENDER).node("_").isEqualTo("display");
+        assertThatJson(noPriority.getDefinition()).node(RENDER).node("sort").isEqualTo("sort");
+        assertThatJson(noPriority.getDefinition()).node(RESPONSIVE_PRIORITY).isAbsent();
+
+        TableColumn withPriority = builder.withResponsivePriority(1).build();
+        assertThatJson(withPriority.getDefinition()).node(RESPONSIVE_PRIORITY).isEqualTo(1);
     }
 
     @Test
     void shouldCreateColumnWithOtherProperties() {
-        TableColumn column = new TableColumn(LABEL, "simple")
-                .setHeaderClass(ColumnCss.DATE)
-                .setWidth(WIDTH);
+        ColumnBuilder builder = new ColumnBuilder();
 
-        assertThat(column).hasHeaderLabel(LABEL);
-        assertThat(column).hasDefinition("{  \"data\": \"simple\",  \"defaultContent\": \"\"}");
-        assertThat(column).hasHeaderClass("date");
-        assertThat(column).hasWidth(WIDTH);
+        TableColumn column = builder.withHeaderLabel(LABEL)
+                .withDataPropertyKey(KEY)
+                .withHeaderClass(ColumnCss.DATE)
+                .withType("integer")
+                .build();
+
+        assertThat(column).hasHeaderLabel(LABEL).hasHeaderClass("date");
+        assertThatJson(column.getDefinition()).node(DATA).isEqualTo(KEY);
+        assertThatJson(column.getDefinition()).node(TYPE).isEqualTo("integer");
     }
 
     @Test
@@ -83,20 +104,5 @@ class TableColumnTest {
                         + "<svg class=\"details-icon svg-icon\"><use href></use>"
                         + "</svg>"
                         + "</div>");
-    }
-
-    @Test
-    void shouldCreateHiddenColumn() {
-        TableColumn column = new TableColumn(LABEL, "Hidden", "String")
-                .setHeaderClass(ColumnCss.HIDDEN)
-                .setWidth(0);
-
-        assertThat(column).hasHeaderLabel(LABEL);
-        assertThat(column).hasDefinition("{  \"type\": \"String\",  "
-                + "\"data\": \"Hidden\",  "
-                + "\"defaultContent\": \"\",  "
-                + "\"render\": {     \"_\": \"display\",     \"sort\": \"sort\"  }}");
-        assertThat(column).hasHeaderClass("hidden");
-        assertThat(column).hasWidth(0);
     }
 }

--- a/src/test/java/io/jenkins/plugins/datatables/TableColumnTest.java
+++ b/src/test/java/io/jenkins/plugins/datatables/TableColumnTest.java
@@ -64,13 +64,13 @@ class TableColumnTest {
 
         TableColumn noPriority = builder.withHeaderLabel(LABEL)
                 .withDataPropertyKey(KEY)
-                .withType("integer")
+                .withType(ColumnType.STRING)
                 .withDetailedCell()
                 .build();
 
         assertThat(noPriority).hasHeaderLabel(LABEL).hasHeaderClass(StringUtils.EMPTY);
         assertThatJson(noPriority.getDefinition()).node(DATA).isEqualTo(KEY);
-        assertThatJson(noPriority.getDefinition()).node(TYPE).isEqualTo("integer");
+        assertThatJson(noPriority.getDefinition()).node(TYPE).isEqualTo("string");
         assertThatJson(noPriority.getDefinition()).node(RENDER).node("_").isEqualTo("display");
         assertThatJson(noPriority.getDefinition()).node(RENDER).node("sort").isEqualTo("sort");
         assertThatJson(noPriority.getDefinition()).node(RESPONSIVE_PRIORITY).isAbsent();
@@ -85,13 +85,25 @@ class TableColumnTest {
 
         TableColumn column = builder.withHeaderLabel(LABEL)
                 .withDataPropertyKey(KEY)
-                .withHeaderClass(ColumnCss.DATE)
-                .withType("integer")
                 .build();
 
-        assertThat(column).hasHeaderLabel(LABEL).hasHeaderClass("date");
+        assertThat(column).hasHeaderLabel(LABEL);
         assertThatJson(column.getDefinition()).node(DATA).isEqualTo(KEY);
-        assertThatJson(column.getDefinition()).node(TYPE).isEqualTo("integer");
+    }
+
+    @Test
+    void shouldVerifyCssStyle() {
+        ColumnBuilder builder = new ColumnBuilder().withHeaderLabel(LABEL).withDataPropertyKey(KEY);
+
+        assertThat(builder.withHeaderClass(ColumnCss.NO_SORT)
+                .build()).hasHeaderClass("nosort");
+
+        assertThat(builder.withType(ColumnType.NUMBER)
+                .build()).hasHeaderClass("text-end");
+        assertThat(builder.withHeaderClass(ColumnCss.PERCENTAGE)
+                .build()).hasHeaderClass("percentage");
+        assertThat(builder.withType(ColumnType.FORMATTED_NUMBER)
+                .build()).hasHeaderClass("text-end");
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/datatables/TableColumnTest.java
+++ b/src/test/java/io/jenkins/plugins/datatables/TableColumnTest.java
@@ -7,6 +7,7 @@ import io.jenkins.plugins.util.JenkinsFacade;
 
 import static io.jenkins.plugins.datatables.TableColumn.*;
 import static io.jenkins.plugins.datatables.assertions.Assertions.*;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -17,6 +18,10 @@ import static org.mockito.Mockito.*;
 class TableColumnTest {
     private static final String LABEL = "label";
     private static final int WIDTH = 2;
+    private static final String RESPONSIVE_PRIORITY = "responsivePriority";
+    private static final String DATA = "data";
+    private static final String DEFAULT_CONTENT = "defaultContent";
+    private static final String TYPE = "type";
 
     @Test
     void shouldCreateColumnWithSimpleDescription() {
@@ -26,6 +31,13 @@ class TableColumnTest {
         assertThat(column).hasDefinition("{  \"data\": \"one\",  \"defaultContent\": \"\"}");
         assertThat(column).hasHeaderClass(StringUtils.EMPTY);
         assertThat(column).hasWidth(1);
+
+        assertThatJson(column.getDefinition()).node(DATA).isEqualTo("one");
+        assertThatJson(column.getDefinition()).node(DEFAULT_CONTENT).asString().isEmpty();
+        assertThatJson(column.getDefinition()).node(RESPONSIVE_PRIORITY).isAbsent();
+
+        column.setPriority(1);
+        assertThatJson(column.getDefinition()).node(RESPONSIVE_PRIORITY).isEqualTo(1);
     }
 
     @Test
@@ -39,6 +51,14 @@ class TableColumnTest {
                 + "\"render\": {     \"_\": \"display\",     \"sort\": \"sort\"  }}");
         assertThat(column).hasHeaderClass(StringUtils.EMPTY);
         assertThat(column).hasWidth(1);
+
+        column.setPriority(1);
+        assertThatJson(column.getDefinition()).node(DATA).isEqualTo("one");
+        assertThatJson(column.getDefinition()).node(DEFAULT_CONTENT).asString().isEmpty();
+        assertThatJson(column.getDefinition()).node(RESPONSIVE_PRIORITY).isEqualTo(1);
+        assertThatJson(column.getDefinition()).node(TYPE).isEqualTo("integer");
+        assertThatJson(column.getDefinition()).node("render").node("_").isEqualTo("display");
+        assertThatJson(column.getDefinition()).node("render").node("sort").isEqualTo("sort");
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/datatables/TableConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/datatables/TableConfigurationTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import io.jenkins.plugins.datatables.TableConfiguration.SelectStyle;
 
 import static io.jenkins.plugins.datatables.TableConfigurationAssert.*;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
 
 /**
  * Tests for the class {@link TableConfiguration}.
@@ -12,7 +13,6 @@ import static io.jenkins.plugins.datatables.TableConfigurationAssert.*;
  * @author Andreas Pabst
  */
 public class TableConfigurationTest {
-
     @Test
     void shouldCreateEmptyConfiguration() {
         TableConfiguration configuration = new TableConfiguration();
@@ -21,6 +21,16 @@ public class TableConfigurationTest {
         assertThat(configuration).isNotUseButtons();
         assertThat(configuration).isNotUseColReorder();
         assertThat(configuration).isNotUseResponsive();
+        assertThat(configuration).isNotUseStateSave();
+
+        assertThatJson(configuration).satisfiesAnyOf(
+                t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
+                t -> assertThatJson(t).node("useResponsive").isEqualTo(false),
+                t -> assertThatJson(t).node("useColReorder").isEqualTo(false),
+                t -> assertThatJson(t).node("useButtons").isEqualTo(false),
+                t -> assertThatJson(t).node("stateSave").isEqualTo(false),
+                t -> assertThatJson(t).node("useSelect").isEqualTo(false)
+        );
     }
 
     @Test
@@ -32,6 +42,16 @@ public class TableConfigurationTest {
         assertThat(configuration).isNotUseButtons();
         assertThat(configuration).isNotUseColReorder();
         assertThat(configuration).isUseResponsive();
+        assertThat(configuration).isNotUseStateSave();
+
+        assertThatJson(configuration).satisfiesAnyOf(
+                t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
+                t -> assertThatJson(t).node("useResponsive").isEqualTo(true),
+                t -> assertThatJson(t).node("useColReorder").isEqualTo(false),
+                t -> assertThatJson(t).node("useButtons").isEqualTo(false),
+                t -> assertThatJson(t).node("stateSave").isEqualTo(false),
+                t -> assertThatJson(t).node("useSelect").isEqualTo(false)
+        );
     }
 
     @Test
@@ -43,6 +63,16 @@ public class TableConfigurationTest {
         assertThat(configuration).isNotUseColReorder();
         assertThat(configuration).isNotUseResponsive();
         assertThat(configuration).isUseSelect();
+        assertThat(configuration).isNotUseStateSave();
+
+        assertThatJson(configuration).satisfiesAnyOf(
+                t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
+                t -> assertThatJson(t).node("useResponsive").isEqualTo(false),
+                t -> assertThatJson(t).node("useColReorder").isEqualTo(false),
+                t -> assertThatJson(t).node("useButtons").isEqualTo(false),
+                t -> assertThatJson(t).node("stateSave").isEqualTo(false),
+                t -> assertThatJson(t).node("useSelect").asString().isEqualTo("single")
+        );
     }
 
     @Test
@@ -54,6 +84,16 @@ public class TableConfigurationTest {
         assertThat(configuration).isNotUseButtons();
         assertThat(configuration).isUseColReorder();
         assertThat(configuration).isNotUseResponsive();
+        assertThat(configuration).isNotUseStateSave();
+
+        assertThatJson(configuration).satisfiesAnyOf(
+                t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
+                t -> assertThatJson(t).node("useResponsive").isEqualTo(false),
+                t -> assertThatJson(t).node("useColReorder").isEqualTo(true),
+                t -> assertThatJson(t).node("useButtons").isEqualTo(false),
+                t -> assertThatJson(t).node("stateSave").isEqualTo(false),
+                t -> assertThatJson(t).node("useSelect").isEqualTo(false)
+        );
     }
 
     @Test
@@ -65,6 +105,16 @@ public class TableConfigurationTest {
         assertThat(configuration).isUseButtons();
         assertThat(configuration).isNotUseColReorder();
         assertThat(configuration).isNotUseResponsive();
+        assertThat(configuration).isNotUseStateSave();
+
+        assertThatJson(configuration).satisfiesAnyOf(
+                t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
+                t -> assertThatJson(t).node("useResponsive").isEqualTo(false),
+                t -> assertThatJson(t).node("useColReorder").isEqualTo(false),
+                t -> assertThatJson(t).node("useButtons").isEqualTo(true),
+                t -> assertThatJson(t).node("stateSave").isEqualTo(false),
+                t -> assertThatJson(t).node("useSelect").isEqualTo(false)
+        );
     }
 
     @Test
@@ -76,6 +126,16 @@ public class TableConfigurationTest {
         assertThat(configuration).isUseButtons();
         assertThat(configuration).isNotUseColReorder();
         assertThat(configuration).isNotUseResponsive();
+        assertThat(configuration).isNotUseStateSave();
+
+        assertThatJson(configuration).satisfiesAnyOf(
+                t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
+                t -> assertThatJson(t).node("useResponsive").isEqualTo(false),
+                t -> assertThatJson(t).node("useColReorder").isEqualTo(false),
+                t -> assertThatJson(t).node("useButtons").isEqualTo("colvis: \"print\""),
+                t -> assertThatJson(t).node("stateSave").isEqualTo(false),
+                t -> assertThatJson(t).node("useSelect").isEqualTo(false)
+        );
     }
 
     @Test
@@ -87,6 +147,15 @@ public class TableConfigurationTest {
         assertThat(configuration).isNotUseButtons();
         assertThat(configuration).isNotUseColReorder();
         assertThat(configuration).isNotUseResponsive();
-    }
+        assertThat(configuration).isUseStateSave();
 
+        assertThatJson(configuration).satisfiesAnyOf(
+                t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
+                t -> assertThatJson(t).node("useResponsive").isEqualTo(false),
+                t -> assertThatJson(t).node("useColReorder").isEqualTo(false),
+                t -> assertThatJson(t).node("useButtons").isEqualTo(false),
+                t -> assertThatJson(t).node("useSelect").isEqualTo(false),
+                t -> assertThatJson(t).node("stateSave").isEqualTo(true)
+        );
+    }
 }

--- a/src/test/java/io/jenkins/plugins/datatables/TableModelTest.java
+++ b/src/test/java/io/jenkins/plugins/datatables/TableModelTest.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import io.jenkins.plugins.datatables.TableModel.DetailedCell;
+import io.jenkins.plugins.datatables.TableColumn.ColumnBuilder;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
 import static org.mockito.Mockito.*;
@@ -31,32 +31,23 @@ class TableModelTest {
     }
 
     @Test
-    void shouldCreateSimpleColumns() {
+    void shouldCreateColumns() {
         TableModel tableModel = spy(TableModel.class);
 
         List<TableColumn> columns = new ArrayList<>();
-        columns.add(new TableColumn("left", "leftProperty"));
+        columns.add(createColumn("left", "leftProperty"));
         when(tableModel.getColumns()).thenReturn(columns);
 
         assertThatJson(tableModel.getColumnsDefinition()).isArray().hasSize(1).containsExactly(
-                "{data:\"leftProperty\",defaultContent:\"\"}");
+                "{data:\"leftProperty\"}");
 
-        columns.add(new TableColumn("right", "rightProperty"));
+        columns.add(createColumn("right", "rightProperty"));
         assertThatJson(tableModel.getColumnsDefinition()).isArray().hasSize(2).containsExactly(
-                "{data:\"leftProperty\",defaultContent:\"\"}",
-                "{data:\"rightProperty\",defaultContent:\"\"}");
+                "{data:\"leftProperty\"}", "{data:\"rightProperty\"}");
     }
 
-    @Test
-    void shouldCreateDetailedCellColumns() {
-        TableModel tableModel = spy(TableModel.class);
-
-        List<TableColumn> columns = new ArrayList<>();
-        columns.add(new TableColumn("left", "leftProperty", "integer"));
-        when(tableModel.getColumns()).thenReturn(columns);
-
-        assertThatJson(tableModel.getColumnsDefinition()).isArray().hasSize(1).containsExactly(
-                "{data:\"leftProperty\",defaultContent:\"\", render:{_:\"display\",sort:\"sort\"},type:\"integer\"}]");
+    private TableColumn createColumn(final String label, final String property) {
+        return new ColumnBuilder().withHeaderLabel(label).withDataPropertyKey(property).build();
     }
 
     @Test
@@ -64,7 +55,7 @@ class TableModelTest {
         TableModel tableModel = spy(TableModel.class);
 
         List<TableColumn> columns = new ArrayList<>();
-        columns.add(new TableColumn("left", "leftProperty", "integer"));
+        columns.add(createColumn("left", "leftProperty"));
         when(tableModel.getColumns()).thenReturn(columns);
 
         assertThatJson(tableModel.getTableConfiguration()).satisfiesAnyOf(

--- a/src/test/java/io/jenkins/plugins/datatables/TableModelTest.java
+++ b/src/test/java/io/jenkins/plugins/datatables/TableModelTest.java
@@ -39,11 +39,11 @@ class TableModelTest {
         when(tableModel.getColumns()).thenReturn(columns);
 
         assertThatJson(tableModel.getColumnsDefinition()).isArray().hasSize(1).containsExactly(
-                "{data:\"leftProperty\"}");
+                "{data:\"leftProperty\",\"type\":\"string\"}");
 
         columns.add(createColumn("right", "rightProperty"));
         assertThatJson(tableModel.getColumnsDefinition()).isArray().hasSize(2).containsExactly(
-                "{data:\"leftProperty\"}", "{data:\"rightProperty\"}");
+                "{data:\"leftProperty\",\"type\":\"string\"}", "{data:\"rightProperty\",\"type\":\"string\"}");
     }
 
     private TableColumn createColumn(final String label, final String property) {

--- a/src/test/java/io/jenkins/plugins/datatables/TableModelTest.java
+++ b/src/test/java/io/jenkins/plugins/datatables/TableModelTest.java
@@ -1,10 +1,14 @@
 package io.jenkins.plugins.datatables;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import io.jenkins.plugins.datatables.TableModel.DetailedCell;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests the class {@link TableModel}.
@@ -24,5 +28,51 @@ class TableModelTest {
         DetailedCell<Integer> cell = new DetailedCell<>("Display", 123);
 
         assertThatJson(cell).isEqualTo("{display: \"Display\", sort: 123}");
+    }
+
+    @Test
+    void shouldCreateSimpleColumns() {
+        TableModel tableModel = spy(TableModel.class);
+
+        List<TableColumn> columns = new ArrayList<>();
+        columns.add(new TableColumn("left", "leftProperty"));
+        when(tableModel.getColumns()).thenReturn(columns);
+
+        assertThatJson(tableModel.getColumnsDefinition()).isArray().hasSize(1).containsExactly(
+                "{data:\"leftProperty\",defaultContent:\"\"}");
+
+        columns.add(new TableColumn("right", "rightProperty"));
+        assertThatJson(tableModel.getColumnsDefinition()).isArray().hasSize(2).containsExactly(
+                "{data:\"leftProperty\",defaultContent:\"\"}",
+                "{data:\"rightProperty\",defaultContent:\"\"}");
+    }
+
+    @Test
+    void shouldCreateDetailedCellColumns() {
+        TableModel tableModel = spy(TableModel.class);
+
+        List<TableColumn> columns = new ArrayList<>();
+        columns.add(new TableColumn("left", "leftProperty", "integer"));
+        when(tableModel.getColumns()).thenReturn(columns);
+
+        assertThatJson(tableModel.getColumnsDefinition()).isArray().hasSize(1).containsExactly(
+                "{data:\"leftProperty\",defaultContent:\"\", render:{_:\"display\",sort:\"sort\"},type:\"integer\"}]");
+    }
+
+    @Test
+    void shouldCreateEmptyConfiguration() {
+        TableModel tableModel = spy(TableModel.class);
+
+        List<TableColumn> columns = new ArrayList<>();
+        columns.add(new TableColumn("left", "leftProperty", "integer"));
+        when(tableModel.getColumns()).thenReturn(columns);
+
+        assertThatJson(tableModel.getTableConfiguration()).satisfiesAnyOf(
+                t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
+                t -> assertThatJson(t).node("useResponsive").isEqualTo(false),
+                t -> assertThatJson(t).node("useColReorder").isEqualTo(false),
+                t -> assertThatJson(t).node("useButtons").isEqualTo(false),
+                t -> assertThatJson(t).node("useSelect").isEqualTo(false)
+        );
     }
 }


### PR DESCRIPTION
In order to simplify the usage of the responsive table configuration, support for [responsive priority](https://datatables.net/extensions/responsive/priority) has been added. `TableColumn` instances should be created by the associated `ColumnBuilder` from now on.