### PR TITLE
Use new Jenkins styles for Boostrap tabs

### DIFF
--- a/src/main/webapp/css/jenkins-style.css
+++ b/src/main/webapp/css/jenkins-style.css
@@ -23,12 +23,6 @@ tfoot {
     border-color: #b4b4b4;
 }
 
-/* Add padding-top for more space */
-.tab-content > .active {
-    display: block;
-    padding-top: 20px;
-}
-
 /* Add color for search (filter) highlighting */
 .highlight {
     background-color: var(--menu-selected-color);
@@ -56,7 +50,7 @@ div.details-control {
 /* ------------------------------------------------------------------------------------------------------------------- */
 
 .col-width-0 {
-    width: 0%;
+    width: 0;
 }
 .col-width-1 {
     width: 8.333333%;


### PR DESCRIPTION
Spacing for tabs should be set in Bootstrap plugin only.

Required by jenkinsci/bootstrap5-api-plugin#158.