### PR TITLE
Re-populate the search query input box

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -56,7 +56,12 @@ with the following piece of code:
   [...]
 
     <div class="table-responsive">
-        <table class="table table-hover table-striped display" id="id">
+        <table
+          class="table table-hover table-striped display"
+          id="id"
+          <!-- enable to remember last search text. Per default false -->
+          data-remember-search-text="true"
+          >
             [...]
         </table>
     </div>

--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -175,6 +175,17 @@ jQuery3(document).ready(function () {
             if ($.isNumeric(storedLength)) {
                 dataTable.page.len(storedLength).draw();
             }
+
+            // Store search text
+            if (table.attr('remember-search-text') === 'true') {
+                table.on( 'search.dt', function () {
+                    localStorage.setItem(id + '#table-search-text', dataTable.search());
+                });
+                const storedSearchText = localStorage.getItem(id + '#table-search-text');
+                if (storedSearchText) {
+                    dataTable.search(storedSearchText).draw();
+                }
+            }
         });
     }
 

--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -177,7 +177,7 @@ jQuery3(document).ready(function () {
             }
 
             // Store search text
-            if (table.attr('remember-search-text') === 'true') {
+            if (table.attr('data-remember-search-text') === 'true') {
                 table.on( 'search.dt', function () {
                     localStorage.setItem(id + '#table-search-text', dataTable.search());
                 });


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

The search box is a very important part of the UI. 
However when there is a need to refresh the page, it's cumbersome to have to re-enter the search query after every action.

The search query should be automatically re-populated after an page reload.

To enable / disable this scenario might be the table-attribute 'remember-search-text' used.
like
```
 <div class="table-responsive">
    <table class="jenkins-table jenkins-!-margin-bottom-4 data-table"
           id="lockable-resources"
          isLoaded="true"
          remember-search-text="true"
          data-columns-definition="[null, null, null, null, null]"
          data-table-configuration="{}">
      <colgroup>
...
```

Per default it is set to false, that means disabled, therefore it shall has no side effects in plugins currently used this API.

We need this feature to fix this [issue](https://github.com/jenkinsci/lockable-resources-plugin/issues/461)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- ~~[ ] Link to relevant pull requests, esp. upstream and downstream changes~~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
