### PR TITLE
Adapt tables to Jenkins design language (light and dark theme)

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -4,7 +4,7 @@ set -e
 
 JENKINS_HOME=../docker/volumes/jenkins-home
 
-mvn clean install || { echo "Build failed"; exit 1; }
+mvn -o clean install || { echo "Build failed"; exit 1; }
 
 echo "Installing plugin in $JENKINS_HOME"
 

--- a/src/main/webapp/css/jenkins-style.css
+++ b/src/main/webapp/css/jenkins-style.css
@@ -6,21 +6,10 @@ tfoot {
     font-weight: bold;
 }
 
-/* Change color of active pagination, to fit to the material blue grey css */
-.pagination > .active > a, .pagination > .active > a:focus, .pagination > .active > a:hover, .pagination > .active > span, .pagination > .active > span:focus, .pagination > .active > span:hover {
-    background-color: #b4b4b4;
-    border-color: #b4b4b4;
-}
-
-/* Change color of inactive pagination, to fit to the material blue grey css */
-.pagination > li > a, .pagination > li > span {
-    color: #b4b4b4;
-}
-
-/* Change color of active pagination, to fit to the material blue grey css */
-.page-item.active .page-link {
-    background-color: #b4b4b4;
-    border-color: #b4b4b4;
+div.dataTables_wrapper div.dataTables_paginate ul.pagination {
+    margin: 2px 4px 4px 0;
+    white-space: nowrap;
+    justify-content: flex-end;
 }
 
 /* Add color for search (filter) highlighting */
@@ -83,10 +72,23 @@ div.details-control {
 /* ------------------------------------------------------------------------------------------------------------------- */
 /* DataTables select                                                                                                  */
 /* ------------------------------------------------------------------------------------------------------------------- */
-table.dataTable tbody > tr.selected, table.dataTable tbody > tr > .selected {
-    background-color: #b4b4b4 !important;
+
+table.dataTable.table-striped > tbody > tr.odd > * {
+    box-shadow: inset 0 0 0 9999px var(--table-background);
+    color: var(--text-color)
 }
 
-table.dataTable tbody tr.selected, table.dataTable tbody th.selected, table.dataTable tbody td.selected {
-    color: black !important;
+table.dataTable.table-striped > tbody > tr.even > * {
+    box-shadow: inset 0 0 0 9999px var(--background);
+    color: var(--text-color)
+}
+
+table.dataTable.table-striped > tbody > tr.odd.selected > * {
+    box-shadow: inset 0 0 0 9999px var(--medium-grey);
+    color: var(--text-color)
+}
+
+table.dataTable.table-striped > tbody > tr.even.selected > * {
+    box-shadow: inset 0 0 0 9999px var(--medium-grey);
+    color: var(--text-color)
 }

--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -36,7 +36,7 @@ jQuery3(document).ready(function () {
                                     return '-';
                                 }
                                 const dateTime = luxon.DateTime.fromMillis(data * 1000);
-                                return '<span data-bs-toggle="tooltip" data-bs-placement="bottom" title="'
+                                return '<span data-bs-toggle="tooltip" data-bs-placement="top" title="'
                                     + dateTime.toLocaleString(luxon.DateTime.DATETIME_SHORT) + '">'
                                     + dateTime.toRelative({locale: 'en'}) + '</span>';
                             }


### PR DESCRIPTION
Fixed the following topics:

- Striped tables on light and dark themes. 
- Removed hovering of rows. 
- Make selection of a row visible on all themes
- Fix pagination controls styling. 
- Use CSS variables for all stylings

Fixes the DataTables related tasks of https://github.com/jenkinsci/code-coverage-api-plugin/issues/228.

## Light Theme

![Bildschirmfoto 2023-05-19 um 12 19 03](https://github.com/jenkinsci/data-tables-api-plugin/assets/503338/eaeee586-d490-44d1-86c6-ed9e8dd0a393)

## Dark Theme

![Bildschirmfoto 2023-05-19 um 12 18 45](https://github.com/jenkinsci/data-tables-api-plugin/assets/503338/3ad327cd-622a-45e2-ab67-658c6ff4ce8a)

