### PR TITLE
Enable built-in auto-save functionality of DataTables

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -57,11 +57,7 @@ with the following piece of code:
 
     <div class="table-responsive">
         <table
-          class="table table-hover table-striped display"
-          id="id"
-          <!-- enable to remember last search text. Per default false -->
-          data-remember-search-text="true"
-          >
+          class="table table-striped display" id="id">
             [...]
         </table>
     </div>

--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -145,7 +145,10 @@ jQuery3(document).ready(function () {
                 });
             }
 
-            if (!table.hasClass("custom-persistence-off")) {
+            // Since Jenkins 2.406 Prototype has been removed from core.
+            // So we basically do not need to support a custom serialization of the data-tables state
+            // anymore. We can now use the default auto-save functionality of DataTables.
+            if (typeof Prototype === 'object') {
                 // Add event listener that stores the order a user selects
                 table.on('order.dt', function () {
                     const order = table.DataTable().order();


### PR DESCRIPTION
Do not use custom serialization anymore when Prototype is not loaded. The new feature requires Jenkins 2.406 or newer. For older versions, the old custom serialization is used.

