### PR TITLE
Add ability to disable paging

### DIFF
--- a/src/main/java/io/jenkins/plugins/datatables/TableConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/datatables/TableConfiguration.java
@@ -20,6 +20,7 @@ public class TableConfiguration {
     private boolean useButtons = false;
     private boolean useSelect = false;
     private boolean useStateSave = false;
+    private boolean usePaging = true;
 
     /**
      * Make the table responsive, i.e. the columns wrap over to a child column.
@@ -148,6 +149,28 @@ public class TableConfiguration {
      */
     public boolean isUseStateSave() {
         return useStateSave;
+    }
+
+    /**
+     * Disable paging.
+     *
+     * @return this {@link TableConfiguration} for chaining methods
+     *
+     * @see <a href="https://datatables.net/reference/option/paging">https://datatables.net/reference/option/paging</a>
+     */
+    public TableConfiguration noPaging() {
+        configuration.put("paging", false);
+        usePaging = false;
+        return this;
+    }
+
+    /**
+     * Returns whether paging is configured to be used.
+     *
+     * @return true, if paging should be used, false otherwise.
+     */
+    public boolean isUsePaging() {
+        return usePaging;
     }
 
     /**

--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -17,6 +17,7 @@ jQuery3(document).ready(function () {
                     details: false
                 },
                 deferRender: true,
+                paging: true,
                 pagingType: 'numbers', // page number button only
                 order: [[1, 'asc']], // default order, if not persisted yet
                 columnDefs: [

--- a/src/test/java/io/jenkins/plugins/datatables/TableConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/datatables/TableConfigurationTest.java
@@ -22,6 +22,7 @@ public class TableConfigurationTest {
         assertThat(configuration).isNotUseColReorder();
         assertThat(configuration).isNotUseResponsive();
         assertThat(configuration).isNotUseStateSave();
+        assertThat(configuration).isUsePaging();
 
         assertThatJson(configuration).satisfiesAnyOf(
                 t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
@@ -29,7 +30,8 @@ public class TableConfigurationTest {
                 t -> assertThatJson(t).node("useColReorder").isEqualTo(false),
                 t -> assertThatJson(t).node("useButtons").isEqualTo(false),
                 t -> assertThatJson(t).node("stateSave").isEqualTo(false),
-                t -> assertThatJson(t).node("useSelect").isEqualTo(false)
+                t -> assertThatJson(t).node("useSelect").isEqualTo(false),
+                t -> assertThatJson(t).node("paging").isEqualTo(true)
         );
     }
 
@@ -43,6 +45,7 @@ public class TableConfigurationTest {
         assertThat(configuration).isNotUseColReorder();
         assertThat(configuration).isUseResponsive();
         assertThat(configuration).isNotUseStateSave();
+        assertThat(configuration).isUsePaging();
 
         assertThatJson(configuration).satisfiesAnyOf(
                 t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
@@ -50,7 +53,8 @@ public class TableConfigurationTest {
                 t -> assertThatJson(t).node("useColReorder").isEqualTo(false),
                 t -> assertThatJson(t).node("useButtons").isEqualTo(false),
                 t -> assertThatJson(t).node("stateSave").isEqualTo(false),
-                t -> assertThatJson(t).node("useSelect").isEqualTo(false)
+                t -> assertThatJson(t).node("useSelect").isEqualTo(false),
+                t -> assertThatJson(t).node("paging").isEqualTo(true)
         );
     }
 
@@ -64,6 +68,7 @@ public class TableConfigurationTest {
         assertThat(configuration).isNotUseResponsive();
         assertThat(configuration).isUseSelect();
         assertThat(configuration).isNotUseStateSave();
+        assertThat(configuration).isUsePaging();
 
         assertThatJson(configuration).satisfiesAnyOf(
                 t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
@@ -71,7 +76,8 @@ public class TableConfigurationTest {
                 t -> assertThatJson(t).node("useColReorder").isEqualTo(false),
                 t -> assertThatJson(t).node("useButtons").isEqualTo(false),
                 t -> assertThatJson(t).node("stateSave").isEqualTo(false),
-                t -> assertThatJson(t).node("useSelect").asString().isEqualTo("single")
+                t -> assertThatJson(t).node("useSelect").asString().isEqualTo("single"),
+                t -> assertThatJson(t).node("paging").isEqualTo(true)
         );
     }
 
@@ -85,6 +91,7 @@ public class TableConfigurationTest {
         assertThat(configuration).isUseColReorder();
         assertThat(configuration).isNotUseResponsive();
         assertThat(configuration).isNotUseStateSave();
+        assertThat(configuration).isUsePaging();
 
         assertThatJson(configuration).satisfiesAnyOf(
                 t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
@@ -92,7 +99,8 @@ public class TableConfigurationTest {
                 t -> assertThatJson(t).node("useColReorder").isEqualTo(true),
                 t -> assertThatJson(t).node("useButtons").isEqualTo(false),
                 t -> assertThatJson(t).node("stateSave").isEqualTo(false),
-                t -> assertThatJson(t).node("useSelect").isEqualTo(false)
+                t -> assertThatJson(t).node("useSelect").isEqualTo(false),
+                t -> assertThatJson(t).node("paging").isEqualTo(true)
         );
     }
 
@@ -106,6 +114,7 @@ public class TableConfigurationTest {
         assertThat(configuration).isNotUseColReorder();
         assertThat(configuration).isNotUseResponsive();
         assertThat(configuration).isNotUseStateSave();
+        assertThat(configuration).isUsePaging();
 
         assertThatJson(configuration).satisfiesAnyOf(
                 t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
@@ -113,7 +122,8 @@ public class TableConfigurationTest {
                 t -> assertThatJson(t).node("useColReorder").isEqualTo(false),
                 t -> assertThatJson(t).node("useButtons").isEqualTo(true),
                 t -> assertThatJson(t).node("stateSave").isEqualTo(false),
-                t -> assertThatJson(t).node("useSelect").isEqualTo(false)
+                t -> assertThatJson(t).node("useSelect").isEqualTo(false),
+                t -> assertThatJson(t).node("paging").isEqualTo(true)
         );
     }
 
@@ -127,6 +137,7 @@ public class TableConfigurationTest {
         assertThat(configuration).isNotUseColReorder();
         assertThat(configuration).isNotUseResponsive();
         assertThat(configuration).isNotUseStateSave();
+        assertThat(configuration).isUsePaging();
 
         assertThatJson(configuration).satisfiesAnyOf(
                 t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
@@ -134,7 +145,8 @@ public class TableConfigurationTest {
                 t -> assertThatJson(t).node("useColReorder").isEqualTo(false),
                 t -> assertThatJson(t).node("useButtons").isEqualTo("colvis: \"print\""),
                 t -> assertThatJson(t).node("stateSave").isEqualTo(false),
-                t -> assertThatJson(t).node("useSelect").isEqualTo(false)
+                t -> assertThatJson(t).node("useSelect").isEqualTo(false),
+                t -> assertThatJson(t).node("paging").isEqualTo(true)
         );
     }
 
@@ -148,6 +160,7 @@ public class TableConfigurationTest {
         assertThat(configuration).isNotUseColReorder();
         assertThat(configuration).isNotUseResponsive();
         assertThat(configuration).isUseStateSave();
+        assertThat(configuration).isUsePaging();
 
         assertThatJson(configuration).satisfiesAnyOf(
                 t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
@@ -155,7 +168,31 @@ public class TableConfigurationTest {
                 t -> assertThatJson(t).node("useColReorder").isEqualTo(false),
                 t -> assertThatJson(t).node("useButtons").isEqualTo(false),
                 t -> assertThatJson(t).node("useSelect").isEqualTo(false),
-                t -> assertThatJson(t).node("stateSave").isEqualTo(true)
+                t -> assertThatJson(t).node("stateSave").isEqualTo(true),
+                t -> assertThatJson(t).node("paging").isEqualTo(true)
+        );
+    }
+
+    @Test
+    void shouldCreateNoPagingConfiguration() {
+        TableConfiguration configuration = new TableConfiguration()
+                .noPaging();
+
+        assertThat(configuration).hasConfiguration("{\"paging\":false}");
+        assertThat(configuration).isNotUseButtons();
+        assertThat(configuration).isNotUseColReorder();
+        assertThat(configuration).isNotUseResponsive();
+        assertThat(configuration).isNotUseStateSave();
+        assertThat(configuration).isNotUsePaging();
+
+        assertThatJson(configuration).satisfiesAnyOf(
+                t -> assertThatJson(t).node("configuration").asString().isEqualTo("{}"),
+                t -> assertThatJson(t).node("useResponsive").isEqualTo(false),
+                t -> assertThatJson(t).node("useColReorder").isEqualTo(false),
+                t -> assertThatJson(t).node("useButtons").isEqualTo(false),
+                t -> assertThatJson(t).node("useSelect").isEqualTo(false),
+                t -> assertThatJson(t).node("stateSave").isEqualTo(false),
+                t -> assertThatJson(t).node("paging").isEqualTo(false)
         );
     }
 }


### PR DESCRIPTION
Added a `noPaging()` method on `TableConfiguration` that disables the DataTables paging functionality.

### Testing done

Extended test harness to cover new configuration option.
Tested usage within another plugin in Jenkins - Paging is correctly disabled.

#### With Paging
![data-tables-api-paging](https://github.com/jenkinsci/data-tables-api-plugin/assets/45196583/00a02be3-754b-47c1-a92d-6381cc19a718)

#### Without Paging
![data-tables-api-no-paging](https://github.com/jenkinsci/data-tables-api-plugin/assets/45196583/243cfa59-99d9-426b-bd3d-1177fb9c5c5e)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
