### PR TITLE
Enable architecture tests

### DIFF
--- a/src/test/java/io/jenkins/plugins/datatables/PackageArchitectureTest.java
+++ b/src/test/java/io/jenkins/plugins/datatables/PackageArchitectureTest.java
@@ -1,0 +1,28 @@
+package io.jenkins.plugins.datatables;
+
+import java.net.URL;
+
+import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.Configuration.*;
+import static com.tngtech.archunit.library.plantuml.rules.PlantUmlArchCondition.*;
+
+/**
+ * Checks the package architecture of this plugin.
+ *
+ * @author Ullrich Hafner
+ */
+@SuppressWarnings("hideutilityclassconstructor")
+@AnalyzeClasses(packages = "io.jenkins.plugins.datatables", importOptions = DoNotIncludeTests.class)
+class PackageArchitectureTest {
+    private static final URL PACKAGE_DESIGN = PackageArchitectureTest.class.getResource("/design.puml");
+
+    @ArchTest
+    static final ArchRule ADHERES_TO_PACKAGE_DESIGN
+            = classes().should(adhereToPlantUmlDiagram(PACKAGE_DESIGN,
+            consideringOnlyDependenciesInAnyPackage("io.jenkins.plugins.datatables")));
+}

--- a/src/test/java/io/jenkins/plugins/datatables/PluginArchitectureTest.java
+++ b/src/test/java/io/jenkins/plugins/datatables/PluginArchitectureTest.java
@@ -1,0 +1,59 @@
+package io.jenkins.plugins.datatables;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import edu.hm.hafner.util.ArchitectureRules;
+
+import io.jenkins.plugins.util.PluginArchitectureRules;
+
+/**
+ * Checks several architecture rules for the plugin utilities.
+ *
+ * @author Ullrich Hafner
+ */
+@SuppressWarnings("hideutilityclassconstructor")
+@AnalyzeClasses(packages = "io.jenkins.plugins.datatables")
+class PluginArchitectureTest {
+    @ArchTest
+    static final ArchRule NO_EXCEPTIONS_WITH_NO_ARG_CONSTRUCTOR = ArchitectureRules.NO_EXCEPTIONS_WITH_NO_ARG_CONSTRUCTOR;
+
+    @ArchTest
+    static final ArchRule NO_PUBLIC_TEST_CLASSES = ArchitectureRules.NO_PUBLIC_TEST_CLASSES;
+
+    @ArchTest
+    static final ArchRule NO_PUBLIC_TEST_METHODS = ArchitectureRules.ONLY_PACKAGE_PRIVATE_TEST_METHODS;
+
+    @ArchTest
+    static final ArchRule NO_TEST_API_CALLED = ArchitectureRules.NO_TEST_API_CALLED;
+
+    @ArchTest
+    static final ArchRule NO_FORBIDDEN_ANNOTATION_USED = ArchitectureRules.NO_FORBIDDEN_ANNOTATION_USED;
+
+    @ArchTest
+    static final ArchRule NO_FORBIDDEN_CLASSES_CALLED = ArchitectureRules.NO_FORBIDDEN_CLASSES_CALLED;
+
+    @ArchTest static final ArchRule ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS = ArchitectureRules.ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS;
+
+    @ArchTest
+    static final ArchRule NO_JENKINS_INSTANCE_CALL = PluginArchitectureRules.NO_JENKINS_INSTANCE_CALL;
+
+    @ArchTest
+    static final ArchRule NO_FORBIDDEN_PACKAGE_ACCESSED = PluginArchitectureRules.NO_FORBIDDEN_PACKAGE_ACCESSED;
+
+    @ArchTest
+    static final ArchRule AJAX_PROXY_METHOD_MUST_BE_IN_PUBLIC_CLASS = PluginArchitectureRules.AJAX_PROXY_METHOD_MUST_BE_IN_PUBLIC_CLASS;
+
+    @ArchTest
+    static final ArchRule DATA_BOUND_CONSTRUCTOR_MUST_BE_IN_PUBLIC_CLASS = PluginArchitectureRules.DATA_BOUND_CONSTRUCTOR_MUST_BE_IN_PUBLIC_CLASS;
+
+    @ArchTest
+    static final ArchRule DATA_BOUND_SETTER_MUST_BE_IN_PUBLIC_CLASS = PluginArchitectureRules.DATA_BOUND_SETTER_MUST_BE_IN_PUBLIC_CLASS;
+
+    @ArchTest
+    static final ArchRule USE_POST_FOR_VALIDATION_END_POINTS = PluginArchitectureRules.USE_POST_FOR_VALIDATION_END_POINTS;
+
+    @ArchTest
+    static final ArchRule USE_POST_FOR_LIST_MODELS_RULE = PluginArchitectureRules.USE_POST_FOR_LIST_AND_COMBOBOX_FILL;
+}

--- a/src/test/java/io/jenkins/plugins/datatables/TableConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/datatables/TableConfigurationTest.java
@@ -12,7 +12,7 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.*;
  *
  * @author Andreas Pabst
  */
-public class TableConfigurationTest {
+class TableConfigurationTest {
     @Test
     void shouldCreateEmptyConfiguration() {
         TableConfiguration configuration = new TableConfiguration();

--- a/src/test/resources/archunit_ignore_patterns.txt
+++ b/src/test/resources/archunit_ignore_patterns.txt
@@ -1,0 +1,1 @@
+// empty up to now, see https://www.archunit.org/userguide/html/000_Index.html#_ignoring_violations

--- a/src/test/resources/design.puml
+++ b/src/test/resources/design.puml
@@ -1,0 +1,11 @@
+@startuml
+
+skinparam componentStyle uml2
+skinparam component {
+  BorderColor #a0a0a0
+  BackgroundColor #f8f8f8
+}
+
+[DataTables API] <<..datatables>>
+
+@enduml


### PR DESCRIPTION
Since Java code will be added to these JS libraries as well it makes sense to enable the Java architecture tests.
