### PR TITLE
Use frontend-maven-plugin configuration of parent POM.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "remark-preset-lint-recommended": "6.1.3"
   },
   "scripts": {
-    "lint-md": "remark ."
+    "lint-md": "remark .",
+    "mvnbuild": "",
+    "mvntest": ""
   },
   "remarkConfig": {
     "plugins": [

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>6.10.0</version>
+    <version>6.12.0</version>
     <relativePath />
   </parent>
 
@@ -114,33 +114,6 @@
             </fileset>
           </filesets>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>com.github.eirslett</groupId>
-        <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.13.4</version>
-        <executions>
-          <execution>
-            <id>install node and npm</id>
-            <goals>
-              <goal>install-node-and-npm</goal>
-            </goals>
-            <phase>generate-resources</phase>
-            <configuration>
-              <nodeVersion>v18.12.0</nodeVersion>
-            </configuration>
-          </execution>
-          <execution>
-            <id>npm install</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <phase>generate-resources</phase>
-            <configuration>
-              <arguments>install</arguments>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+git pull
+git push
+mvn -B clean release:prepare release:perform


### PR DESCRIPTION
NPM and Node versions are now derived from [analysis-pom](https://github.com/jenkinsci/analysis-pom-plugin/blob/master/pom.xml). `frontend-maven-plugin` configuration is now derived from [plugin-pom](https://github.com/jenkinsci/plugin-pom/blob/master/pom.xml).