### PR TITLE
Correctly hide and show the detail buttons on table redraws

### DIFF
--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -136,6 +136,15 @@ jQuery3(document).ready(function () {
                     const tooltip = new bootstrap5.Tooltip($(this)[0]);
                     tooltip.enable();
                 });
+                table.find('.details-icon-close').each(function () {
+                    $(this).hide();
+                });
+                table.find('.details-icon-open').each(function () {
+                    $(this).show();
+                });
+                table.rows().every(function () {
+                    this.child.hide();
+                });
             });
 
             if (table.is(":visible")) {


### PR DESCRIPTION
After a table is sorted or filtered, the state of the details buttons should be reset to closed.

