### PR TITLE
Remove custom serialization, use built-in auto save

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,11 @@
     <revision>1.13.8-1</revision>
     <changelist>-SNAPSHOT</changelist>
 
-    <json-unit-assertj.version>2.38.0</json-unit-assertj.version>
     <module.name>${project.groupId}.datatables</module.name>
 
+    <jenkins.version>2.426.1</jenkins.version>
+
+    <json-unit-assertj.version>2.38.0</json-unit-assertj.version>
   </properties>
 
   <licenses>

--- a/src/main/webapp/js/table.js
+++ b/src/main/webapp/js/table.js
@@ -9,7 +9,7 @@ jQuery3(document).ready(function () {
          */
         function createDataTable(table) {
             const defaultConfiguration = {
-                stateSave: typeof Prototype !== 'object', // do not save state when Prototype is still loaded
+                stateSave: true,
                 language: {
                     emptyTable: 'Loading - please wait ...'
                 },
@@ -162,56 +162,6 @@ jQuery3(document).ready(function () {
                 table.on('becameVisible', function () {
                     loadTableData(table, dataTable);
                 });
-            }
-
-            // TODO: Remove this block once Jenkins 2.426.1 is released
-            // Since Jenkins 2.406 Prototype has been removed.
-            // So we basically do not need to support a custom serialization of the data-tables state
-            // anymore. We can now use the default auto-save functionality of DataTables.
-            if (typeof Prototype === 'object') {
-                // Add event listener that stores the order a user selects
-                table.on('order.dt', function () {
-                    const order = table.DataTable().order();
-                    localStorage.setItem(id + '#orderBy', order[0][0]);
-                    localStorage.setItem(id + '#orderDirection', order[0][1]);
-                });
-
-                /**
-                 * Restores the order of every table by reading the local storage of the browser.
-                 * If no order has been stored yet, the table is skipped.
-                 * Also saves the default length of the number of table columns.
-                 */
-                const orderBy = localStorage.getItem(id + '#orderBy');
-                const orderDirection = localStorage.getItem(id + '#orderDirection');
-                if (orderBy && orderDirection) {
-                    const order = [orderBy, orderDirection];
-                    try {
-                        dataTable.order(order).draw();
-                    }
-                    catch (ignore) { // TODO: find a way to determine the number of columns here
-                        dataTable.order([[1, 'asc']]).draw();
-                    }
-                }
-
-                // Store paging size
-                table.on('length.dt', function (e, settings, len) {
-                    localStorage.setItem(id + '#table-length', len);
-                });
-                const storedLength = localStorage.getItem(id + '#table-length');
-                if ($.isNumeric(storedLength)) {
-                    dataTable.page.len(storedLength).draw();
-                }
-
-                // Store search text
-                if (table.attr('data-remember-search-text') === 'true') {
-                    table.on('search.dt', function () {
-                        localStorage.setItem(id + '#table-search-text', dataTable.search());
-                    });
-                    const storedSearchText = localStorage.getItem(id + '#table-search-text');
-                    if (storedSearchText) {
-                        dataTable.search(storedSearchText).draw();
-                    }
-                }
             }
         });
     }


### PR DESCRIPTION
With the removal of Prototype.js from core we can now use the built-in functionality for auto-saving the state of the tabels.