### PR TITLE
Use explicit versions for all plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,14 @@
   "dependencies": {
     "datatables.net": "1.13.8",
     "datatables.net-bs5": "1.13.8",
-    "datatables.net-buttons-bs5": "2.4.2",
-    "datatables.net-colreorder-bs5": "1.7.0",
-    "datatables.net-responsive-bs5": "2.5.0",
-    "datatables.net-select-bs5": "1.7.0",
+    "datatables.net-buttons": "2.4.3",
+    "datatables.net-buttons-bs5": "2.4.3",
+    "datatables.net-colreorder": "1.7.2",
+    "datatables.net-colreorder-bs5": "1.7.2",
+    "datatables.net-responsive": "2.5.1",
+    "datatables.net-responsive-bs5": "2.5.1",
+    "datatables.net-select": "1.7.1",
+    "datatables.net-select-bs5": "1.7.1",
     "datatables.mark.js": "2.1.0",
     "mark.js": "8.11.1",
     "luxon": "3.4.4"


### PR DESCRIPTION
Otherwise the latest not-compatible version might be picked up.