### PR TITLE
Add a builder method to disable detailed cell rendering

### DIFF
--- a/src/main/java/io/jenkins/plugins/datatables/TableColumn.java
+++ b/src/main/java/io/jenkins/plugins/datatables/TableColumn.java
@@ -298,6 +298,17 @@ public class TableColumn {
         }
 
         /**
+         * Disables the rendering of cells with the {@link DetailedCell} format. A cell then simply contains a value.
+         *
+         * @return this column
+         */
+        public ColumnBuilder withPlainValueCell() {
+            this.isDetailedCellEnabled = false;
+
+            return this;
+        }
+
+        /**
          * Creates a new {@link TableColumn} based on the specified builder configuration.
          *
          * @return the created {@link TableColumn}

--- a/src/test/java/io/jenkins/plugins/datatables/TableColumnTest.java
+++ b/src/test/java/io/jenkins/plugins/datatables/TableColumnTest.java
@@ -74,6 +74,11 @@ class TableColumnTest {
 
         TableColumn withPriority = builder.withResponsivePriority(1).build();
         assertThatJson(withPriority.getDefinition()).node(RESPONSIVE_PRIORITY).isEqualTo(1);
+        assertThatJson(withPriority.getDefinition()).node(RENDER).node("_").isEqualTo("display");
+        assertThatJson(withPriority.getDefinition()).node(RENDER).node("sort").isEqualTo("sort");
+
+        TableColumn withSimple = builder.withPlainValueCell().build();
+        assertThatJson(withSimple.getDefinition()).node(RENDER).isAbsent();
     }
 
     @Test


### PR DESCRIPTION
Otherwise all columns after the first occurrence of a details cell will use the details cell property.