### PR TITLE
Revert version of j2html to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <version>7.1328.v9b_cc5d0c1c14</version>
+      <version>7.1330.v47b_46ee2047a_</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
Versions starting from 1.5.0 are not backward-compatible anymore.